### PR TITLE
execute mongod directly instead of via shell

### DIFF
--- a/lib/Test/mongod.pm
+++ b/lib/Test/mongod.pm
@@ -104,10 +104,10 @@ sub BUILD {
                 my $logfile = ($self->has_config && $self->config->{logfile}) ? $self->config->{logfile} : 'mongod.log';
                 my $logpath = $self->dbpath . "/$logfile";
     
-                my $cmd = sprintf("%s --dbpath %s --port %u --logpath %s ", $self->mongod, $self->dbpath, $self->port, $logpath);
-                $cmd .= sprintf(" --bind_ip %s", $self->bind_ip) unless ($self->bind_ip eq '127.0.0.1');
-                $cmd .= ' --quiet' if $self->quiet;
-                exec ( $cmd );
+                my @cmd = ($self->mongod, '--dbpath', $self->dbpath, '--port', $self->port, '--logpath', $logpath);
+                push @cmd, '--bind_ip', $self->bind_ip unless $self->bind_ip eq '127.0.0.1';
+                push @cmd, '--quiet' if $self->quiet;
+                exec @cmd;
         }
         until ( wait_port($self->port, 1) ) { sleep 1; }
         $self->pid($pid);


### PR DESCRIPTION
When I tried to install Test::mongod test hanged. After investigating I found that test wasn't stopping mongo because of the way exec is used in the script.
exec("mongod --dbpath...") executes shell that forks and executes
mongod in a child process. As a result $mongod->stop stops the shell
process, but mongod continues running. List form of exec, executes
mongod directly and so avoiding this problem. As a bonus it works when
paths contain spaces.
